### PR TITLE
Adapt to the changed queueserver API in main

### DIFF
--- a/src/queueserver.ts
+++ b/src/queueserver.ts
@@ -77,7 +77,7 @@ export interface IPlanObjectsState {
 }
 
 export const getQueuedPlans = async(): Promise<IPlanObject[]> => {
-    const res = await axiosInstance.get('/queue_view');
+    const res = await axiosInstance.get('/get_queue');
     console.log(res);
     return res.data.queue;
 }


### PR DESCRIPTION
This is a simple change to accommodate the new endpoint name for viewing
the contents of the queue.