### PR TITLE
Added two more buttons for environments and queues

### DIFF
--- a/src/acquire.tsx
+++ b/src/acquire.tsx
@@ -9,7 +9,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import { IApplicationState } from './store';
-import { submitPlan } from './planactions';
+import { submitPlan, modifyEnvironment, modifyQueue } from './planactions';
 import { clearQueue } from './planactions';
 import { IPlanObject } from './queueserver';
 import {
@@ -22,6 +22,8 @@ interface Props extends RouteComponentProps<RouteParams> { }
 
 interface IProps extends RouteComponentProps {
     submitPlan: typeof submitPlan;
+    modifyEnvironment: typeof modifyEnvironment;
+    modifyQueue: typeof modifyQueue;
     clearQueue: typeof clearQueue;
     loading: boolean;
     plan: IPlanObject;
@@ -30,6 +32,10 @@ interface IProps extends RouteComponentProps {
 interface IState {
     planId: number;
     onPlanChange: (planId: number) => void;
+    env: string;
+    onEnvChange: (env: string) => void;
+    queue: string;
+    onQueueChange: (queue: string) => void;
 }
 
 class AcquirePage extends React.Component<IProps, IState> {
@@ -37,7 +43,11 @@ class AcquirePage extends React.Component<IProps, IState> {
         super(props);
         this.state = {
           planId: -1,
-          onPlanChange: this.handlePlanChange
+          onPlanChange: this.handlePlanChange,
+          env: "Open",
+          onEnvChange: this.handleEnvChange,
+          queue: "Start",
+          onQueueChange: this.handleQueueChange,
         };
       }
     render() {
@@ -69,6 +79,11 @@ class AcquirePage extends React.Component<IProps, IState> {
             <div><pre>The pretty printed JSON:<br />
                 { JSON.stringify(this.props.plan, null, 2) }</pre></div>
           </Box>
+          <Box my={4}>
+              <Button variant="contained" onClick={this.handleEnvClick}>{this.state.env} environment</Button>
+              <Button variant="contained" onClick={this.handleQueueClick}>{this.state.queue} queue</Button>
+
+          </Box>
         </Container>
         )
     }
@@ -81,8 +96,38 @@ class AcquirePage extends React.Component<IProps, IState> {
         this.setState({ planId });
     };
 
+    private handleEnvChange = (env: string) => {
+        this.setState({ env });
+    };
+
+    private handleQueueChange = (queue: string) => {
+        this.setState({ queue });
+    };
+
     private handleSubmitClick = () => {
         this.props.submitPlan(this.state.planId);
+    }
+
+    private handleEnvClick = () => {
+        if (this.state.env === "Open") {
+            this.props.modifyEnvironment(0);
+            this.state.onEnvChange("Close");
+        }
+        else {
+            this.props.modifyEnvironment(1);
+            this.state.onEnvChange("Open");
+        }
+    }
+
+    private handleQueueClick = () => {
+        if (this.state.queue === "Start") {
+            this.props.modifyQueue(0);
+            this.state.onQueueChange("Stop");
+        }
+        else {
+            this.props.modifyQueue(1);
+            this.state.onQueueChange("Start");
+        }
     }
 
     private handleClearQueue = () => {
@@ -102,6 +147,8 @@ const mapStateToProps = (store: IApplicationState) => {
 
 const mapDispatchToProps = (dispatch: any) => {
     return {
+      modifyEnvironment: (opId: number) => dispatch(modifyEnvironment(opId)),
+      modifyQueue: (opId: number) => dispatch(modifyQueue(opId)),
       submitPlan: (planId: number) => dispatch(submitPlan(planId)),
       clearQueue: () => dispatch(clearQueue()),
     };

--- a/src/planactions.ts
+++ b/src/planactions.ts
@@ -3,7 +3,9 @@ import { ThunkAction } from "redux-thunk"
 import { getOverview as getOverviewAPI,
     getQueuedPlans as getQueuedPlansAPI,
     submitPlan as submitPlanAPI,
-    clearQueue as clearQueueAPI} from "./queueserver"
+    clearQueue as clearQueueAPI,
+    modifyEnvironment as modifyEnvironmentAPI,
+    modifyQueue as modifyQueueAPI} from "./queueserver"
 import { IPlanGetOverviewAction, IPlanLoadingAction, IPlanObjectsAction, IPlanSubmitAction,
     IPlanState, IPlanObjectsState, IPlanSubmitState, PlanActionTypes} from "./queueserver"
 
@@ -40,6 +42,28 @@ export const submitPlan: ActionCreator<ThunkAction<Promise<AnyAction>, IPlanSubm
         return dispatch({
           plan,
           type: PlanActionTypes.SUBMITPLAN
+        });
+    };
+};
+
+export const modifyEnvironment: ActionCreator<ThunkAction<Promise<AnyAction>, IPlanSubmitState, null, IPlanSubmitAction>> = (planId: number) => {
+    return async (dispatch: Dispatch) => {
+        dispatch(loading());
+        const env = await modifyEnvironmentAPI(planId);
+        return dispatch({
+          env,
+          type: PlanActionTypes.MODIFYENVIRONMENT
+        });
+    };
+};
+
+export const modifyQueue: ActionCreator<ThunkAction<Promise<AnyAction>, IPlanSubmitState, null, IPlanSubmitAction>> = (opId: number) => {
+    return async (dispatch: Dispatch) => {
+        dispatch(loading());
+        const queue = await modifyQueueAPI(opId);
+        return dispatch({
+          queue,
+          type: PlanActionTypes.MODIFYQUEUE
         });
     };
 };

--- a/src/planreducers.ts
+++ b/src/planreducers.ts
@@ -1,5 +1,6 @@
 import { Reducer } from "redux";
-import { IPlanState, IPlanObjectsState, IPlanSubmitState, PlanActions, PlanActionTypes } from "./queueserver";
+import { IPlanState, IPlanObjectsState, IPlanSubmitState, IPlanModifyState,
+    PlanActions, PlanActionTypes } from "./queueserver";
 
 const initialPlanState: IPlanState = {
     plan: {
@@ -94,6 +95,70 @@ export const planSubmitReducer: Reducer<IPlanSubmitState, PlanActions> = (
                 ...state,
                 plan: action.plan,
                 plansLoading: false
+            };
+        }
+        default: {
+            return state;
+        }
+    }
+};
+
+const initialEnvModifyState: IPlanModifyState = {
+    modify: {
+        msg: "",
+        success: false
+    },
+    loading: false
+};
+
+export const environmentModifyReducer: Reducer<IPlanModifyState, PlanActions> = (
+    state = initialEnvModifyState,
+    action
+) => {
+    switch (action.type) {
+        case PlanActionTypes.LOADING: {
+            return {
+                ...state,
+                loading: true
+            };
+        }
+        case PlanActionTypes.MODIFYENVIRONMENT: {
+            return {
+                ...state,
+                modify: action.modify,
+                loading: false
+            };
+        }
+        default: {
+            return state;
+        }
+    }
+};
+
+const initialQueueModifyState: IPlanModifyState = {
+    modify: {
+        msg: "",
+        success: false
+    },
+    loading: false
+};
+
+export const queueModifyReducer: Reducer<IPlanModifyState, PlanActions> = (
+    state = initialQueueModifyState,
+    action
+) => {
+    switch (action.type) {
+        case PlanActionTypes.LOADING: {
+            return {
+                ...state,
+                loading: true
+            };
+        }
+        case PlanActionTypes.MODIFYQUEUE: {
+            return {
+                ...state,
+                modify: action.modify,
+                loading: false
             };
         }
         default: {

--- a/src/queueserver.ts
+++ b/src/queueserver.ts
@@ -10,6 +10,8 @@ export enum PlanActionTypes {
     GETPLANLIST = "PLANS/GETPLANLIST",
     SUBMITPLAN = "PLANS/SUBMITPLAN",
     CLEARQUEUE = "PLANS/CLEARQUEUE",
+    MODIFYENVIRONMENT = "PLANS/MODIFYENVIRONMENT",
+    MODIFYQUEUE = "PLANS/MODIFYQUEUE",
 }
 
 export interface IPlan {
@@ -18,6 +20,11 @@ export interface IPlan {
     plans_in_queue: number,
     running_plan_uid: string,
     worker_environment_exists: boolean
+}
+
+export interface IPlanModify {
+    msg: string;
+    success: boolean;
 }
 
 export interface IPlanGetOverviewAction {
@@ -53,6 +60,24 @@ export interface IPlanSubmitLoadingAction {
     type: PlanActionTypes.LOADING
 }
 
+export interface IPlanModifyEnvironmentAction {
+    type: PlanActionTypes.MODIFYENVIRONMENT,
+    modify: IPlanModify
+}
+
+export interface IPlanModifyEnvironmentLoadingAction {
+    type: PlanActionTypes.LOADING
+}
+
+export interface IPlanModifyQueueAction {
+    type: PlanActionTypes.MODIFYQUEUE,
+    modify: IPlanModify
+}
+
+export interface IPlanModifyQueueLoadingAction {
+    type: PlanActionTypes.LOADING
+}
+
 export type PlanActions =
   | IPlanGetOverviewAction
   | IPlanLoadingAction
@@ -60,6 +85,10 @@ export type PlanActions =
   | IPlanObjectsLoadingAction
   | IPlanSubmitAction
   | IPlanSubmitLoadingAction
+  | IPlanModifyEnvironmentAction
+  | IPlanModifyEnvironmentLoadingAction
+  | IPlanModifyQueueAction
+  | IPlanModifyQueueLoadingAction
 
 export interface IPlanState {
     readonly plan: IPlan;
@@ -114,6 +143,46 @@ export const submitPlan = async(planId: number): Promise<IPlanObject> => {
 export const clearQueue = async(): Promise<IPlan> => {
     const res = await axiosInstance.post('/queue/clear',
         {});
+    console.log(res);
+    return res.data;
+}
+
+export interface IPlanModifyState {
+    readonly modify: IPlanModify;
+    readonly loading: boolean;
+}
+
+export const modifyEnvironment = async(op: number): Promise<IPlanModify> => {
+    var operation = "open";
+    if (op === 0) {
+        operation = "open";
+    }
+    else if (op === 1) {
+        operation = "close";
+    }
+    else if (op === 2) {
+        operation = "destroy";
+    }
+    const res = await axiosInstance.post(`/environment/${operation}`, {});
+    console.log(res);
+    return res.data;
+}
+
+export const modifyQueue = async(op: number): Promise<IPlanModify> => {
+    var operation = "start";
+    if (op === 0) {
+        operation = "start";
+    }
+    else if (op === 1) {
+        operation = "stop";
+    }
+    else if (op === 2) {
+        operation = "halt";
+    }
+    else if (op === 3) {
+        operation = "resume";
+    }
+    const res = await axiosInstance.post(`/queue/${operation}`, {});
     console.log(res);
     return res.data;
 }

--- a/src/store.tsx
+++ b/src/store.tsx
@@ -1,18 +1,23 @@
 import { applyMiddleware, combineReducers, createStore, Store } from "redux"
 import thunk from "redux-thunk"
-import { planObjectsReducer, planReducer, planSubmitReducer } from "./planreducers"
-import { IPlanState, IPlanObjectsState, IPlanSubmitState } from "./queueserver"
+import { planObjectsReducer, planReducer, planSubmitReducer,
+    environmentModifyReducer, queueModifyReducer } from "./planreducers"
+import { IPlanState, IPlanObjectsState, IPlanSubmitState, IPlanModifyState } from "./queueserver"
 
 export interface IApplicationState {
     plan: IPlanState;
     plans: IPlanObjectsState;
     submitted: IPlanSubmitState;
+    environment: IPlanModifyState;
+    queue: IPlanModifyState;
 }
 
 const rootReducer = combineReducers<IApplicationState>({
     plan: planReducer,
     plans: planObjectsReducer,
-    submitted: planSubmitReducer
+    submitted: planSubmitReducer,
+    environment: environmentModifyReducer,
+    queue: queueModifyReducer,
 })
 
 export default function configureStore(): Store<IApplicationState> {


### PR DESCRIPTION
This is hackish, but I want to get something working and see what we
might be missing. It adds an open/close environment button and a
start/stop queue button. It works in the basic sense, but needs more
state in order to report and work as expected. Still, as a stake in the
ground I think this shows some of the interactions we are after.