### PR TITLE
Add tooltips to Clear/Submit buttons

### DIFF
--- a/src/acquire.tsx
+++ b/src/acquire.tsx
@@ -6,6 +6,7 @@ import Button from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
+import Tooltip from '@material-ui/core/Tooltip';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import { IApplicationState } from './store';
@@ -46,7 +47,9 @@ class AcquirePage extends React.Component<IProps, IState> {
           <Box my={4}>
             <Typography variant="h4" component="h1" gutterBottom>
               This is where we will acquire data...
-              <button onClick={this.handleClearQueue}>Clear Queue</button>
+              <Tooltip title="Clear the queue of the queueserver">
+                <button onClick={this.handleClearQueue}>Clear Queue</button>
+              </Tooltip>
             </Typography>
               <Typography variant="h6" component="h1" gutterBottom>
               <div>
@@ -65,7 +68,9 @@ class AcquirePage extends React.Component<IProps, IState> {
                     <MenuItem value={1}>scan</MenuItem>
                 </Select>
             </FormControl>
-            <Button variant="contained" onClick={this.handleSubmitClick}>Submit plan to queue</Button>
+            <Tooltip title="Submit the plan to the queue">
+              <Button variant="contained" onClick={this.handleSubmitClick}>Submit</Button>
+            </Tooltip>
             <div><pre>The pretty printed JSON:<br />
                 { JSON.stringify(this.props.plan, null, 2) }</pre></div>
           </Box>


### PR DESCRIPTION
We discussed it with @cryos via Teams that it would be nicer to have short names for the controls. This PR adds tooltips to the buttons where we can explain the functionality better.

Example:
![Screenshot from 2020-10-09 16-54-48](https://user-images.githubusercontent.com/13209176/95631928-9054ba80-0a52-11eb-8401-0b9951caf969.png)
