### PR TITLE
Add an editable plan parameter, feed it through

### DIFF
--- a/src/acquire.tsx
+++ b/src/acquire.tsx
@@ -9,6 +9,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import Tooltip from '@material-ui/core/Tooltip';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
+import TextField from '@material-ui/core/TextField';
 import { IApplicationState } from './store';
 import { submitPlan, modifyEnvironment, modifyQueue } from './planactions';
 import { clearQueue } from './planactions';
@@ -33,6 +34,8 @@ interface IProps extends RouteComponentProps {
 interface IState {
     planId: number;
     onPlanChange: (planId: number) => void;
+    planParam: number;
+    onPlanParamChange: (planParam: number) => void;
     env: string;
     onEnvChange: (env: string) => void;
     queue: string;
@@ -45,6 +48,8 @@ class AcquirePage extends React.Component<IProps, IState> {
         this.state = {
           planId: -1,
           onPlanChange: this.handlePlanChange,
+          planParam: 10,
+          onPlanParamChange: this.handlePlanParamChange,
           env: "Open",
           onEnvChange: this.handleEnvChange,
           queue: "Start",
@@ -77,6 +82,29 @@ class AcquirePage extends React.Component<IProps, IState> {
                     <MenuItem value={0}>count</MenuItem>
                     <MenuItem value={1}>scan</MenuItem>
                 </Select>
+                {}
+                {(() => {
+                    switch (this.state.planId) {
+                        case 0:
+                            return <TextField
+                                id="filled-number"
+                                label="num"
+                                type="number"
+                                value={this.state.planParam}
+                                onChange={this.handleParamChange}
+                            />;
+                        case 1:
+                            return <TextField
+                                id="filled-number"
+                                label="step"
+                                type="number"
+                                value={this.state.planParam}
+                                onChange={this.handleParamChange}
+                            />;
+                        default:
+                            return <p>Make a choice!</p>;
+                    }
+                })()}
             </FormControl>
             <Tooltip title="Submit the plan to the queue">
               <Button variant="contained" onClick={this.handleSubmitClick}>Submit</Button>
@@ -101,6 +129,14 @@ class AcquirePage extends React.Component<IProps, IState> {
         this.setState({ planId });
     };
 
+    private handleParamChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+        this.state.onPlanParamChange(event.target.value as number);
+    };
+
+    private handlePlanParamChange = (planParam: number) => {
+        this.setState({ planParam });
+    };
+
     private handleEnvChange = (env: string) => {
         this.setState({ env });
     };
@@ -110,7 +146,7 @@ class AcquirePage extends React.Component<IProps, IState> {
     };
 
     private handleSubmitClick = () => {
-        this.props.submitPlan(this.state.planId);
+        this.props.submitPlan(this.state.planId, this.state.planParam);
     }
 
     private handleEnvClick = () => {
@@ -154,7 +190,7 @@ const mapDispatchToProps = (dispatch: any) => {
     return {
       modifyEnvironment: (opId: number) => dispatch(modifyEnvironment(opId)),
       modifyQueue: (opId: number) => dispatch(modifyQueue(opId)),
-      submitPlan: (planId: number) => dispatch(submitPlan(planId)),
+      submitPlan: (planId: number, param: number) => dispatch(submitPlan(planId, param)),
       clearQueue: () => dispatch(clearQueue()),
     };
 };

--- a/src/planactions.ts
+++ b/src/planactions.ts
@@ -35,10 +35,10 @@ export const getQueuedPlans: ActionCreator<ThunkAction<Promise<AnyAction>, IPlan
     };
 };
 
-export const submitPlan: ActionCreator<ThunkAction<Promise<AnyAction>, IPlanSubmitState, null, IPlanSubmitAction>> = (planId: number) => {
+export const submitPlan: ActionCreator<ThunkAction<Promise<AnyAction>, IPlanSubmitState, null, IPlanSubmitAction>> = (planId: number, param: number) => {
     return async (dispatch: Dispatch) => {
         dispatch(loading());
-        const plan = await submitPlanAPI(planId);
+        const plan = await submitPlanAPI(planId, param);
         return dispatch({
           plan,
           type: PlanActionTypes.SUBMITPLAN

--- a/src/queueserver.ts
+++ b/src/queueserver.ts
@@ -123,13 +123,13 @@ export const submitPlan = async(planId: number, param: number): Promise<IPlanObj
         planObj = {
             name: "count",
             args: [["det1", "det2"]],
-            kwargs: {"num": param, "delay": 1}
+            kwargs: {"num": Number(param), "delay": 1}
         };
     }
     else {
         planObj = {
             name: "scan",
-            args: [["det1", "det2"], "motor", -1, 1, param ]
+            args: [["det1", "det2"], "motor", -1, 1, Number(param) ]
         };
     }
     const res = await axiosInstance.post('/queue/plan/add',

--- a/src/queueserver.ts
+++ b/src/queueserver.ts
@@ -117,19 +117,19 @@ export interface IPlanSubmitState {
     readonly planLoading: boolean;
 }
 
-export const submitPlan = async(planId: number): Promise<IPlanObject> => {
+export const submitPlan = async(planId: number, param: number): Promise<IPlanObject> => {
     var planObj = {};
     if (planId === 0) {
         planObj = {
             name: "count",
             args: [["det1", "det2"]],
-            kwargs: {"num": 10, "delay": 1}
+            kwargs: {"num": param, "delay": 1}
         };
     }
     else {
         planObj = {
             name: "scan",
-            args: [["det1", "det2"], "motor", -1, 1, 10 ]
+            args: [["det1", "det2"], "motor", -1, 1, param ]
         };
     }
     const res = await axiosInstance.post('/queue/plan/add',


### PR DESCRIPTION
This is the very minimal version of the editable parameter, where a
single number is fed through from the interface to the RESTful call. For
a more complete solution the scope of editable fields must grow, and the
data structure to pass them through should likely be an array of
key-value pairs. It works, and shows the basic flow of data though.