### PR TITLE
Update the README to be more general on overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ The client proxies to the server on port 60610, if it is running on a different
 port you will need to change that in the `package.json` (or just switch the
 server port to match using --port 60610 when launching it).
 
-The API prefix is set up to default to `/qs` when developing against pods or
-a deployed version, this can be overridden by creating a file in the root of
-the source tree `.env.local` where you define `REACT_APP_API_PREFIX=` to use a
-local instance of the queueserver running standalone for development.
+The queue server API prefix is set up to default to `/qs` when developing
+against pods or a deployed version, this can be overridden by creating a file
+in the root of the source tree `.env.local` where you define overrides to the
+entries in the `.env` file.
 
 See the
 [documentation](https://create-react-app.dev/docs/adding-custom-environment-variables)


### PR DESCRIPTION
The proxy server adds in the same prefix now, and there may be more
default variables defined in the future.