### PR TITLE
Add open/close environment button & handle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { IPlan, IPlanObject } from './queueserver';
 import { PlanList } from './PlanList';
 import { HistoricalPlanList } from './HistoricalPlanList';
 import { CurrentPlan } from './CurrentPlan';
-import { clearQueue } from './planactions';
+import { clearQueue, modifyEnvironment, modifyQueue } from './planactions';
 import { Grid } from '@material-ui/core';
 
 
@@ -32,6 +32,8 @@ interface IProps extends RouteComponentProps {
   getOverview: typeof getOverview;
   getQueuedPlans: typeof getQueuedPlans;
   clearQueue: typeof clearQueue;
+  modifyEnvironment: typeof modifyEnvironment;
+  modifyQueue: typeof modifyQueue;
   loadingPlan: boolean;
   plan: IPlan;
   loadingPlans: boolean;
@@ -45,7 +47,8 @@ class App extends React.Component<IProps> {
           <Box width="80vw" height="2vh"></Box>
           <Grid container spacing={5} direction="row" justify="center">
             <Grid item justify="center" spacing={10} xs={3}>    
-              <PlanList clearQueue={this.props.clearQueue} plans={this.props.plans}> </PlanList>
+              <PlanList clearQueue={this.props.clearQueue} plans={this.props.plans}
+              modifyEnvironment={this.props.modifyEnvironment} modifyQueue={this.props.modifyQueue}> </PlanList>
             </Grid>
             <Grid item justify="center" spacing={10} xs={5}>
               <CurrentPlan plans={this.props.plans}></CurrentPlan> 

--- a/src/PlanList.tsx
+++ b/src/PlanList.tsx
@@ -10,18 +10,34 @@ import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import PauseCircleOutlineIcon from '@material-ui/icons/PauseCircleOutline';
 import PlayCircleOutlineIcon from '@material-ui/icons/PlayCircleOutline';
+import Tooltip from '@material-ui/core/Tooltip';
+import LoopIcon from '@material-ui/icons/Loop';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
-import { IPlanObject, modifyQueue, QueueOps } from './queueserver';
+import { IPlanObject, QueueOps, EnvOps } from './queueserver';
 import { Box, Card, CardContent, Paper, Typography } from '@material-ui/core';
-import { clearQueue } from './planactions';
+import { clearQueue, modifyQueue, modifyEnvironment } from './planactions';
 
 type Plans = {
   plans: IPlanObject[];
   clearQueue: typeof clearQueue;
+  modifyEnvironment: typeof modifyEnvironment;
+  modifyQueue: typeof modifyQueue;
 }
 
+interface IState {
+  env: string;
+  onEnvChange: (env: string) => void;
+}
 
-export class PlanList extends React.Component<Plans>{
+export class PlanList extends React.Component<Plans, IState>{
+  public constructor(props: Plans) {
+    super(props);
+    this.state = {
+      env: "Open",
+      onEnvChange: this.handleEnvChange,
+    };
+  }
+
   handleMoveForward(uid: string) {
     alert(uid);
   }
@@ -30,12 +46,27 @@ export class PlanList extends React.Component<Plans>{
     alert(uid);
   }
 
+  private handleEnvChange = (env: string) => {
+    this.setState({ env });
+  };
+
+  private handleEnvClick = () => {
+    if (this.state.env === "Open") {
+        this.props.modifyEnvironment(EnvOps.open);
+        this.state.onEnvChange("Close");
+    }
+    else {
+        this.props.modifyEnvironment(EnvOps.close);
+        this.state.onEnvChange("Open");
+    }
+  }
+
   handlePlay() {
-    modifyQueue(QueueOps.start);
+    this.props.modifyQueue(QueueOps.start);
   }
 
   handlePause() {
-    modifyQueue(QueueOps.stop);
+    this.props.modifyQueue(QueueOps.stop);
   }
 
   handleDelete(uid: string){
@@ -49,6 +80,11 @@ export class PlanList extends React.Component<Plans>{
               <CardContent>
                 <Typography align="center" variant="h5" component="h1" gutterBottom>
                   Queue
+                  <Tooltip title={`${this.state.env} RE environment`}>
+                  <IconButton onClick={() => this.handleEnvClick()} edge="end" aria-label="comments">
+                    <LoopIcon />
+                  </IconButton>
+                  </Tooltip>
                   <IconButton onClick={() => this.handlePlay()} edge="end" aria-label="comments">
                     <PlayCircleOutlineIcon />
                   </IconButton>

--- a/src/PlanList.tsx
+++ b/src/PlanList.tsx
@@ -81,9 +81,9 @@ export class PlanList extends React.Component<Plans, IState>{
                 <Typography align="center" variant="h5" component="h1" gutterBottom>
                   Queue
                   <Tooltip title={`${this.state.env} RE environment`}>
-                  <IconButton onClick={() => this.handleEnvClick()} edge="end" aria-label="comments">
-                    <LoopIcon />
-                  </IconButton>
+                    <IconButton onClick={() => this.handleEnvClick()} edge="end" aria-label="comments">
+                      <LoopIcon />
+                    </IconButton>
                   </Tooltip>
                   <IconButton onClick={() => this.handlePlay()} edge="end" aria-label="comments">
                     <PlayCircleOutlineIcon />

--- a/src/acquire.tsx
+++ b/src/acquire.tsx
@@ -70,7 +70,8 @@ class AcquirePage extends React.Component<IProps, IState> {
                   <PlanForm submitPlan={this.props.submitPlan} name={this.state.selectedPlan} allowedPlans={this.props.allowedPlans}> </PlanForm>   
                 </Grid>   
                 <Grid item justify="center" spacing={10} xs={3}>
-                  <PlanList clearQueue={this.props.clearQueue} plans={this.props.plans}></PlanList> 
+                  <PlanList clearQueue={this.props.clearQueue} plans={this.props.plans}
+                  modifyEnvironment={this.props.modifyEnvironment} modifyQueue={this.props.modifyQueue}></PlanList>
                 </Grid>
             </Grid>
           </Container>

--- a/src/queueserver.ts
+++ b/src/queueserver.ts
@@ -326,8 +326,8 @@ export const submitPlan = async(submitPlan: ISumbitPlanObject): Promise<IPlanObj
     // TODO: Update this, once the have the correct information from the 
     // queueserver about which kwargs are list.
     for (const [key, value] of Object.entries(submitPlan.kwargs)) {
-      if (key != 'detectors'){
-        if (value[0] != "None"){
+      if (key !== 'detectors'){
+        if (value[0] !== "None"){
             // Convert string to a number if possible.
             // TODO: Use the type information from the server (once available), 
             // and use a numeric input.


### PR DESCRIPTION
This PR implements the "open/close RE environment" functionality via a web-client interface. The tooltip's message automatically displays what it's going to do (e.g., if the environment is close, it will display it will open the environment, and vice versa.)
![Screen Shot 2020-11-20 at 17 41 19](https://user-images.githubusercontent.com/13209176/99856831-d9228780-2b57-11eb-83d3-ccbb49091d14.png)
