### PR TITLE
FIX: be defensive of getting no active runs

### DIFF
--- a/src/CurrentPlan.tsx
+++ b/src/CurrentPlan.tsx
@@ -105,9 +105,9 @@ export class CurrentPlan extends React.Component<Plans, IState> {
 
   getActiveUids(){
     getActiveRuns().then((result) => {
-      if (result[0] !== undefined){
-        this.setState({activeRun: result[0]})
-      } 
+      if (result !== undefined && result.length > 0 && result[0] !== undefined) {
+        this.setState({ activeRun: result[0] })
+      }
     })
   }
 


### PR DESCRIPTION
This prevents the app from crashing and giving a blank screen if no plans have ever been started.